### PR TITLE
Update deprecated lighting param and improve dataloader

### DIFF
--- a/src/data/df_dataset.py
+++ b/src/data/df_dataset.py
@@ -1,7 +1,7 @@
 import math
 
 import pandas as pd
-from PIL import Image
+from PIL import Image, ImageOps
 from torch.utils.data import Dataset
 from torchvision.transforms import functional as F
 
@@ -39,7 +39,7 @@ class DFDataset(Dataset):
         label = self.labels[idx]
 
         with open(img_path, "rb") as f:
-            img = Image.open(f)
+            img = ImageOps.exif_transpose(Image.open(f))
             img.load()
 
         img = img.crop((x, y, min(x + w, img.width), min(y + h, img.height)))

--- a/src/data/load.py
+++ b/src/data/load.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentParser
+import os
 
 import pandas as pd
 
@@ -37,9 +38,10 @@ class CSVLoader(Loader):
     def load_data(self):
         data_df = pd.read_csv(self.data_file)
 
-        data_df["image"] = [
-            f"{self.data_dir}/_ibsdb/images/{im}" for im in data_df["image"]
-        ]
+        if self.data_dir:
+            data_df["image"] = [
+                os.path.join(self.data_dir, im) for im in data_df["image"]
+            ]
 
         return data_df
 
@@ -49,6 +51,6 @@ class CSVLoader(Loader):
             parents=[parent_parser], add_help=False, allow_abbrev=False
         )
         parser.add_argument("--data-file", required=True)
-        parser.add_argument("--data-dir", required=True)
+        parser.add_argument("--data-dir", required=False)
 
         return parser

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -116,7 +116,7 @@ class ResNet50EmbeddingModule(pl.LightningModule):
                 monitor="top1",
                 mode="max",
                 filename="{epoch}-{top1:.2f}",
-                every_n_val_epochs=2,
+                every_n_epochs=2,
             ),
             FixBase(self.fixbase_epoch),
         ]


### PR DESCRIPTION
- `eval_n_val_epoch` was changed to `every_n_epoch` and removed in 1.6.0 [[changelog](https://github.com/Lightning-AI/lightning/blob/master/src/pytorch_lightning/CHANGELOG.md)]
- Add auto-rotate for JPEG images from EXIF
- Make data path system more generic to better handle non-wbia data